### PR TITLE
Require for Schema is Missing 

### DIFF
--- a/src/juxt/iota.clj
+++ b/src/juxt/iota.clj
@@ -2,8 +2,9 @@
 
 (ns juxt.iota
   (:require
-   [clojure.test :refer :all]
-   [clojure.set :as set]))
+    [clojure.test :refer :all]
+    [clojure.set :as set]
+    [schema.core :as s]))
 
 ;; See the test at the end of this ns to understand the point of this code
 


### PR DESCRIPTION
The given macro calls `s/check` but a require for `schema.core` is missing. The problem only surfaces if one uses the schema checks and does not have a require for `[schema.core :as s]`.
