### PR TITLE
add readable synonyms for operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,22 +42,22 @@ It's a little less typing, which might give you the extra time to add more check
 
 ## Valid operators
 
-Operator       | Meaning
----------------|-------------------
-`:=`           | is equal to
-`:!=`          | isn't equal to
-`:-`           | conforms to schema
-`:!-`          | doesn't conform to schema
-`:?`           | satifies predicate
-`:!?`          | doesn't satisfy predicate
-`:#`           | matches regex
-`:!#`          | doesn't match regex
-`:>` or `:⊃`   | is superset of
-`:!>` or `:⊅`  | isn't superset of
-`:<` or `:⊂`   | is subset of
-`:!<` or `:⊄`  | isn't subset of
-`:instanceof`  | is instance of
-`:!instanceof` | isn't instance of
+Operator                          | Meaning
+----------------------------------|-------------------
+`:=` or `:equals`                 | is equal to
+`:!=` or `:not-equals`            | isn't equal to
+`:-` or `:conforms`               | conforms to schema
+`:!-` or `:not-conforms`          | doesn't conform to schema
+`:?` or `:satisfies`              | satifies predicate
+`:!?` or `:not-satisfies`         | doesn't satisfy predicate
+`:#` or `:matches`                | matches regex
+`:!#` or `:not-matches`           | doesn't match regex
+`:>` or `:⊃` or `:superset`       | is superset of
+`:!>` or `:⊅` or `:not-superset`  | isn't superset of
+`:<` or `:⊂` or `:subset`         | is subset of
+`:!<` or `:⊄` or `:not-subset`    | isn't subset of
+`:instanceof` or `:instance`      | is instance of
+`:!instanceof` or `:not-instance` | isn't instance of
 
 ## Paths
 

--- a/src/juxt/iota.cljc
+++ b/src/juxt/iota.cljc
@@ -60,35 +60,35 @@
          ~@(for [[a b c] (partition 3 body)]
              (case b
                ;; Equals?
-               := `(is (= ((as-test-function ~a) ~t) ~c))
-               :!= `(is (not= ((as-test-function ~a) ~t) ~c))
+               (:= :equals) `(is (= ((as-test-function ~a) ~t) ~c))
+               (:!= :not-equals) `(is (not= ((as-test-function ~a) ~t) ~c))
 
                ;; Schema checks
-               :- `(is (nil? (s/check ~c ((as-test-function ~a) ~t))))
-               :!- `(is (not (nil? (s/check ~c ((as-test-function ~a) ~t)))))
+               (:- :conforms) `(is (nil? (s/check ~c ((as-test-function ~a) ~t))))
+               (:!- :not-conforms) `(is (not (nil? (s/check ~c ((as-test-function ~a) ~t)))))
 
                ;; Is?
-               :? `(is (~c ((as-test-function ~a) ~t)))
-               :!? `(is (not (~c ((as-test-function ~a) ~t))))
+               (:? :satisfies) `(is (~c ((as-test-function ~a) ~t)))
+               (:!? :not-satisfies) `(is (not (~c ((as-test-function ~a) ~t))))
 
                ;; Matches regex?
-               :# `(is (re-matches (re-pattern ~c) ((as-test-function ~a) ~t)))
-               :!# `(is (not (re-matches (re-pattern ~c) ((as-test-function ~a) ~t))))
+               (:# :matches) `(is (re-matches (re-pattern ~c) ((as-test-function ~a) ~t)))
+               (:!# :not-matches) `(is (not (re-matches (re-pattern ~c) ((as-test-function ~a) ~t))))
 
                ;; Is superset?
-               (:> :⊃) `(is (set/superset? (set ((as-test-function ~a) ~t)) (set ~c)))
-               (:!> :⊅) `(is (not (set/superset? (set ((as-test-function ~a) ~t)) (set ~c))))
+               (:> :⊃ :superset) `(is (set/superset? (set ((as-test-function ~a) ~t)) (set ~c)))
+               (:!> :⊅ :not-superset) `(is (not (set/superset? (set ((as-test-function ~a) ~t)) (set ~c))))
 
                ;; Is subset?
-               (:< :⊂) `(is (set/subset? (set ((as-test-function ~a) ~t)) (set ~c)))
-               (:!< :⊄) `(is (not (set/subset? (set ((as-test-function ~a) ~t)) (set ~c))))
+               (:< :⊂ :subset) `(is (set/subset? (set ((as-test-function ~a) ~t)) (set ~c)))
+               (:!< :⊄ :not-subset) `(is (not (set/subset? (set ((as-test-function ~a) ~t)) (set ~c))))
 
                ;; Is an instance of
-               :instanceof `(is (instance? ~c ((as-test-function ~a) ~t)))
-               :!instanceof `(is (not (instance? ~c ((as-test-function ~a) ~t))))
+               (:instanceof :instance) `(is (instance? ~c ((as-test-function ~a) ~t)))
+               (:!instanceof :not-instance) `(is (not (instance? ~c ((as-test-function ~a) ~t))))
 
                ;; Every satisfies predicate
-               :∀ `(is (every? ~c ((as-test-function ~a) ~t)))
-               :!∀ `(is (not (every? ~c ((as-test-function ~a) ~t))))
+               (:∀ :every) `(is (every? ~c ((as-test-function ~a) ~t)))
+               (:!∀ :not-every) `(is (not (every? ~c ((as-test-function ~a) ~t))))
 
                ))))))


### PR DESCRIPTION
I really like the `given` structure for making assertions, but find some of the operators a bit difficult to read (and type). I think it doesn't hurt to support both short symbols and longer readable keys.